### PR TITLE
Update genxrayconfig.lua

### DIFF
--- a/trunk/user/shadowsocks/ss/genxrayconfig.lua
+++ b/trunk/user/shadowsocks/ss/genxrayconfig.lua
@@ -46,7 +46,7 @@ log = {
 					users = {
 						{
 							id = server.vmess_id,
-							flow = (server.flow == '1') and "xtls-rprx-direct" or ((server.flow == '2') and "xtls-rprx-splice" or "xtls-rprx-direct"),
+							flow = (server.flow == '1') and "xtls-rprx-direct" or ((server.flow == '2') and "xtls-rprx-splice" or ""),
 							level = tonumber(server.alter_id),
 							encryption = server.security
 						}


### PR DESCRIPTION
删除flow的默认值 xtls-rprx-direct

vless + tls +ws 当配置中含有"flow":"xtls-rprx-direct" 时不可用